### PR TITLE
2023年1月よりManifest V2を使っている拡張機能は動くなるようなのでアップデート

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Scratch Highlight Fullwidth Number",
   "version": "2019.12.10.1",
   "icons": {


### PR DESCRIPTION
https://developer.chrome.com/blog/mv2-transition/ では、2023年1月からとありますが、すでに拡張機能が動いていないようで、この変更により再び動作するようになりました。